### PR TITLE
fix: Update Cloud Run workflow authentication

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -22,10 +22,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PREPROD }}
+
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
         with:
-          service_account_key: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PREPROD }}
           project_id: ${{ secrets.FIREBASE_PROJECT_ID_PREPROD }}
 
       - name: Configure Docker for GCR


### PR DESCRIPTION
- Add separate auth step using google-github-actions/auth@v2
- Remove service_account_key from setup-gcloud (no longer supported)
- Fixes authentication error when pushing Docker images to GCR